### PR TITLE
updating mongodb tag to 4.0

### DIFF
--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -58,7 +58,7 @@ services:
     networks:
       - cocoannotator
   database:
-    image: mongo:4
+    image: mongo:4.0
     container_name: annotator_mongodb
     restart: always
     environment:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -82,7 +82,7 @@ services:
     networks:
       - cocoannotator
   database:
-    image: mongo:4
+    image: mongo:4.0
     container_name: annotator_mongodb
     environment:
       - MONGO_DATA_DIR=/data/db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     networks:
       - cocoannotator
   database:
-    image: mongo:4
+    image: mongo:4.0
     container_name: annotator_mongodb
     restart: always
     environment:


### PR DESCRIPTION
Due to webserver and worker halt, we need to change the tag to older mongodb image.